### PR TITLE
Generate Missing Manifest Entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,20 @@
           <target>1.7</target>
         </configuration>
       </plugin>
+      <plugin>
+      <!-- Build an executable JAR -->
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-jar-plugin</artifactId>
+         <version>2.4</version>
+         <configuration>
+           <archive>
+              <manifest>
+                <addClasspath>true</addClasspath>
+                <mainClass>cryodex.Main</mainClass>
+              </manifest>
+           </archive>
+         </configuration>
+       </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Generates the missing manifest entry so that the Cryodex.jar can be executed
from the command line when built using maven.