### PR TITLE
Quick edit to change MoV thresholds to tournament rules v2

### DIFF
--- a/src/cryodex/modules/armada/ArmadaPlayer.java
+++ b/src/cryodex/modules/armada/ArmadaPlayer.java
@@ -14,11 +14,11 @@ import cryodex.xml.XMLUtils.Element;
 
 class ScoreTable
 {
-    public static final int THRESHOLD_6 = 30;
-    public static final int THRESHOLD_7 = 70;
-    public static final int THRESHOLD_8 = 130;
-    public static final int THRESHOLD_9 = 220;
-    public static final int THRESHOLD_10 = 350;
+    public static final int THRESHOLD_6 = 29;
+    public static final int THRESHOLD_7 = 69;
+    public static final int THRESHOLD_8 = 129;
+    public static final int THRESHOLD_9 = 219;
+    public static final int THRESHOLD_10 = 349;
 }
 public class ArmadaPlayer implements Comparable<ModulePlayer>, XMLObject,
 		ModulePlayer {

--- a/src/cryodex/modules/armada/ArmadaPlayer.java
+++ b/src/cryodex/modules/armada/ArmadaPlayer.java
@@ -14,11 +14,11 @@ import cryodex.xml.XMLUtils.Element;
 
 class ScoreTable
 {
-    public static final int THRESHOLD_6 = 27;
-    public static final int THRESHOLD_7 = 67;
-    public static final int THRESHOLD_8 = 120;
-    public static final int THRESHOLD_9 = 200;
-    public static final int THRESHOLD_10 = 293;
+    public static final int THRESHOLD_6 = 30;
+    public static final int THRESHOLD_7 = 70;
+    public static final int THRESHOLD_8 = 130;
+    public static final int THRESHOLD_9 = 220;
+    public static final int THRESHOLD_10 = 350;
 }
 public class ArmadaPlayer implements Comparable<ModulePlayer>, XMLObject,
 		ModulePlayer {


### PR DESCRIPTION
Changed temporary thresholds for Armada to tournament rules v2.0. Old thresholds assumptions did not match FFGs migration to 400 point tournaments.