### PR TITLE
Round Robin

### DIFF
--- a/src/cryodex/modules/xwing/XWingModule.java
+++ b/src/cryodex/modules/xwing/XWingModule.java
@@ -78,7 +78,8 @@ public class XWingModule implements Module {
 				wizardOptions.getName(), wizardOptions.getPlayerList(),
 				wizardOptions.getInitialSeedingEnum(),
 				wizardOptions.getPoints(), wizardOptions.getEscalationPoints(),
-				wizardOptions.isSingleElimination());
+				wizardOptions.isSingleElimination(),
+				wizardOptions.isRoundRobin());
 
 		CryodexController.registerTournament(tournament);
 

--- a/src/cryodex/modules/xwing/XWingRound.java
+++ b/src/cryodex/modules/xwing/XWingRound.java
@@ -11,10 +11,12 @@ public class XWingRound implements XMLObject {
 	private List<XWingMatch> matches;
 	private XWingRoundPanel panel;
 	private Boolean isSingleElimination = false;
+	private Boolean isRoundRobin = false;
 
 	public XWingRound(Element roundElement, XWingTournament t) {
 		this.isSingleElimination = roundElement
 				.getBooleanFromChild("ISSINGLEELIMINATION");
+		this.isRoundRobin=roundElement.getBooleanFromChild("ISROUNDROBIN");
 
 		Element matchElement = roundElement.getChild("MATCHES");
 
@@ -32,6 +34,7 @@ public class XWingRound implements XMLObject {
 			Integer roundNumber) {
 		this.matches = matches;
 		this.panel = new XWingRoundPanel(t, matches);
+		this.isRoundRobin=t.getIsRoundRobin();
 	}
 
 	public List<XWingMatch> getMatches() {
@@ -53,15 +56,23 @@ public class XWingRound implements XMLObject {
 	public void setSingleElimination(boolean isSingleElimination) {
 		this.isSingleElimination = isSingleElimination;
 	}
+	
+	public void setRoundRobin(boolean isRoundRobin) {
+		this.isRoundRobin = isRoundRobin;
+	}
 
 	public boolean isSingleElimination() {
 		return isSingleElimination == null ? false : isSingleElimination;
 	}
 
+	public boolean isRoundRobin() {
+		return isRoundRobin== null ? false : isRoundRobin;
+	}
 	@Override
 	public StringBuilder appendXML(StringBuilder sb) {
 
 		XMLUtils.appendObject(sb, "ISSINGLEELIMINATION", isSingleElimination());
+		XMLUtils.appendObject(sb, "ISROUNDROBIN", isRoundRobin());
 		XMLUtils.appendList(sb, "MATCHES", "MATCH", getMatches());
 
 		return sb;

--- a/src/cryodex/modules/xwing/XWingTournament.java
+++ b/src/cryodex/modules/xwing/XWingTournament.java
@@ -166,6 +166,11 @@ public class XWingTournament implements XMLObject, Tournament {
 		}
 	}
 
+	public boolean getIsRoundRobin()
+	{
+		return startRoundRobin;
+	}
+	
 	@Override
 	public void setPlayers(List<Player> players) {
 		List<XWingPlayer> xwPlayers = new ArrayList<>();
@@ -403,6 +408,7 @@ public class XWingTournament implements XMLObject, Tournament {
 
 			
 		XWingRound r = new XWingRound(matches, this, roundNumber);
+		//r.setSingleElimination(true);
 		rounds.add(r);
 		{
 			getTournamentGUI().getRoundTabbedPane().addSwissTab(roundNumber,

--- a/src/cryodex/modules/xwing/XWingTournament.java
+++ b/src/cryodex/modules/xwing/XWingTournament.java
@@ -355,6 +355,7 @@ public class XWingTournament implements XMLObject, Tournament {
 		}
 	}
 
+	//Generate consecutive rounds for a Round Robin-tournament
 	private void generateRoundRobinRound(int roundNumber)
 	{
 		List<XWingMatch> matches;
@@ -364,11 +365,23 @@ public class XWingTournament implements XMLObject, Tournament {
 			List<XWingPlayer> tempList = new ArrayList<>();
 			tempList.addAll(getXWingPlayers());
 
+			//"Rotate" some or all of the players to
+			//make the matchups
 			XWingPlayer tempPlayer;
+			
+			//if the number of players are odd, rotate the whole
+			//list of players
+			//if the number of players are even, rotate all
+			//but one player
 			int rotationPlace=0;
 			if(tempList.size()%2==0){
 				rotationPlace++;
 			}
+			
+			//once for each round after the first,
+			//move one player to the back of the list
+			//Either the first in the list (for an odd nr of players)
+			//Or the second in the list (for an even nr of players)
 			for(int n=1;n<roundNumber;n++)
 			{
 				tempPlayer=tempList.remove(rotationPlace);
@@ -391,15 +404,7 @@ public class XWingTournament implements XMLObject, Tournament {
 			
 		XWingRound r = new XWingRound(matches, this, roundNumber);
 		rounds.add(r);
-		if (roundNumber == 1
-				&& startAsSingleElimination
-				&& (matches.size() == 1 || matches.size() == 2
-						|| matches.size() == 4 || matches.size() == 8
-						|| matches.size() == 16 || matches.size() == 32)) {
-			r.setSingleElimination(true);
-			getTournamentGUI().getRoundTabbedPane().addSingleEliminationTab(
-					r.getMatches().size() * 2, r.getPanel());
-		} else {
+		{
 			getTournamentGUI().getRoundTabbedPane().addSwissTab(roundNumber,
 					r.getPanel());
 		}

--- a/src/cryodex/modules/xwing/XWingTournamentCreationWizard.java
+++ b/src/cryodex/modules/xwing/XWingTournamentCreationWizard.java
@@ -530,11 +530,23 @@ public class XWingTournamentCreationWizard extends JDialog {
 						if (nonSwiss.isSelected()) {
 							singleElimination.setEnabled(true);
 							roundRobin.setEnabled(true);
+							if(roundRobin.isSelected())
+							{
+								byGroupRB.setEnabled(false);
+								randomRB.setEnabled(false);
+							}
+							else
+							{
+								byGroupRB.setEnabled(true);
+								randomRB.setEnabled(true);
+							}
 						} else {
 							singleElimination.setEnabled(false);
 							singleElimination.setSelected(false);
 							roundRobin.setEnabled(false);
 							roundRobin.setSelected(false);
+							byGroupRB.setEnabled(true);
+							randomRB.setEnabled(true);
 						}
 					}
 				};
@@ -544,6 +556,8 @@ public class XWingTournamentCreationWizard extends JDialog {
 				epicRB.addActionListener(customListener);
 				customRB.addActionListener(customListener);
 				nonSwiss.addActionListener(customListener);
+				roundRobin.addActionListener(customListener);
+				singleElimination.addActionListener(customListener);
 				
 				customPointsTF = new JTextField();
 				customPointsTF.setColumns(12);
@@ -679,6 +693,7 @@ public class XWingTournamentCreationWizard extends JDialog {
 					wizardOptions.setRoundRobin(true);
 				}
 			}
+
 
 			boolean fixByes = true;
 

--- a/src/cryodex/modules/xwing/XWingTournamentCreationWizard.java
+++ b/src/cryodex/modules/xwing/XWingTournamentCreationWizard.java
@@ -418,9 +418,11 @@ public class XWingTournamentCreationWizard extends JDialog {
 		private JRadioButton randomRB;
 		private JRadioButton byGroupRB;
 		private JRadioButton byRankingRB;
+		
 		private JRadioButton singleElimination;
 		private JRadioButton roundRobin;
-
+		private JCheckBox nonSwiss;  
+		
 		private JTextField customPointsTF;
 		private JRadioButton standardRB;
 		private JRadioButton escalationRB;
@@ -459,6 +461,8 @@ public class XWingTournamentCreationWizard extends JDialog {
 				randomRB = new JRadioButton("Random");
 				byGroupRB = new JRadioButton("Seperate By Group Name");
 				byRankingRB = new JRadioButton("By Ranking");
+				
+				nonSwiss = new JCheckBox("Non-Swiss alternatives");
 				singleElimination = new JRadioButton(
 						"<HTML>Start event as single elimination<br>(only for 2/4/8/16/32 players)</HTML>");
 				roundRobin = new JRadioButton("<HTML>Start event as Round Robin");
@@ -477,8 +481,11 @@ public class XWingTournamentCreationWizard extends JDialog {
 						&& wizardOptions.getSelectedTournaments().isEmpty() == false) {
 					tournamentTypesPanel.add(byRankingRB);
 				}
+				tournamentTypesPanel.add(nonSwiss);
 				tournamentTypesPanel.add(singleElimination);
 				tournamentTypesPanel.add(roundRobin);
+				roundRobin.setEnabled(false);
+				singleElimination.setEnabled(false);
 				
 				SpringUtilities
 						.makeCompactGrid(tournamentTypesPanel,
@@ -520,6 +527,15 @@ public class XWingTournamentCreationWizard extends JDialog {
 						} else {
 							customPointsTF.setEnabled(false);
 						}
+						if (nonSwiss.isSelected()) {
+							singleElimination.setEnabled(true);
+							roundRobin.setEnabled(true);
+						} else {
+							singleElimination.setEnabled(false);
+							singleElimination.setSelected(false);
+							roundRobin.setEnabled(false);
+							roundRobin.setSelected(false);
+						}
 					}
 				};
 
@@ -527,7 +543,8 @@ public class XWingTournamentCreationWizard extends JDialog {
 				escalationRB.addActionListener(customListener);
 				epicRB.addActionListener(customListener);
 				customRB.addActionListener(customListener);
-
+				nonSwiss.addActionListener(customListener);
+				
 				customPointsTF = new JTextField();
 				customPointsTF.setColumns(12);
 				customPointsTF.setEnabled(false);
@@ -653,13 +670,15 @@ public class XWingTournamentCreationWizard extends JDialog {
 						.setInitialSeedingEnum(InitialSeedingEnum.IN_ORDER);
 			}
 
-			if (singleElimination.isSelected()) {
-				wizardOptions.setSingleElimination(true);
+			if(nonSwiss.isSelected())
+			{
+				if (singleElimination.isSelected()) {
+					wizardOptions.setSingleElimination(true);
+				}
+				else if(roundRobin.isSelected()) {
+					wizardOptions.setRoundRobin(true);
+				}
 			}
-			else if(roundRobin.isSelected()) {
-				wizardOptions.setRoundRobin(true);
-			}
-			
 
 			boolean fixByes = true;
 

--- a/src/cryodex/modules/xwing/XWingTournamentCreationWizard.java
+++ b/src/cryodex/modules/xwing/XWingTournamentCreationWizard.java
@@ -56,7 +56,7 @@ public class XWingTournamentCreationWizard extends JDialog {
 		this.add(getMainPanel());
 		setCurrentPage(new MainPage());
 		XWingTournamentCreationWizard.this.pack();
-		this.setMinimumSize(new Dimension(450, 500));
+		this.setMinimumSize(new Dimension(450, 300));
 	}
 
 	private void setCurrentPage(Page page) {
@@ -220,6 +220,8 @@ public class XWingTournamentCreationWizard extends JDialog {
 		public JPanel getPanel() {
 
 			setButtonVisibility(null, true, null);
+			
+			XWingTournamentCreationWizard.this.setMinimumSize(new Dimension(450, 300));
 
 			if (pagePanel == null) {
 				JPanel namePanel = new JPanel(new BorderLayout());
@@ -323,6 +325,8 @@ public class XWingTournamentCreationWizard extends JDialog {
 		public JPanel getPanel() {
 
 			setButtonVisibility(true, true, null);
+			
+			XWingTournamentCreationWizard.this.setMinimumSize(new Dimension(450, 500));
 
 			if (pagePanel == null) {
 
@@ -414,7 +418,8 @@ public class XWingTournamentCreationWizard extends JDialog {
 		private JRadioButton randomRB;
 		private JRadioButton byGroupRB;
 		private JRadioButton byRankingRB;
-		private JCheckBox singleElimination;
+		private JRadioButton singleElimination;
+		private JRadioButton roundRobin;
 
 		private JTextField customPointsTF;
 		private JRadioButton standardRB;
@@ -432,6 +437,8 @@ public class XWingTournamentCreationWizard extends JDialog {
 		public JPanel getPanel() {
 
 			setButtonVisibility(true, null, true);
+			
+			XWingTournamentCreationWizard.this.setMinimumSize(new Dimension(450, 500));
 
 			if (pagePanel == null) {
 
@@ -447,17 +454,21 @@ public class XWingTournamentCreationWizard extends JDialog {
 				JPanel tournamentTypesPanel = new JPanel(new SpringLayout());
 
 				ButtonGroup bg = new ButtonGroup();
+				ButtonGroup bg2 = new ButtonGroup();
 
 				randomRB = new JRadioButton("Random");
 				byGroupRB = new JRadioButton("Seperate By Group Name");
 				byRankingRB = new JRadioButton("By Ranking");
-				singleElimination = new JCheckBox(
+				singleElimination = new JRadioButton(
 						"<HTML>Start event as single elimination<br>(only for 2/4/8/16/32 players)</HTML>");
-
+				roundRobin = new JRadioButton("<HTML>Start event as Round Robin");
 				bg.add(randomRB);
 				bg.add(byGroupRB);
 				bg.add(byRankingRB);
-
+				
+				bg2.add(singleElimination);
+				bg2.add(roundRobin);
+				
 				randomRB.setSelected(true);
 
 				tournamentTypesPanel.add(randomRB);
@@ -467,7 +478,8 @@ public class XWingTournamentCreationWizard extends JDialog {
 					tournamentTypesPanel.add(byRankingRB);
 				}
 				tournamentTypesPanel.add(singleElimination);
-
+				tournamentTypesPanel.add(roundRobin);
+				
 				SpringUtilities
 						.makeCompactGrid(tournamentTypesPanel,
 								tournamentTypesPanel.getComponentCount(), 1, 0,
@@ -568,6 +580,7 @@ public class XWingTournamentCreationWizard extends JDialog {
 				if (wizardOptions.getSelectedTournaments() != null
 						&& wizardOptions.getSelectedTournaments().isEmpty() == false) {
 					splitOptionsSubPanel.add(splitByRanking);
+					XWingTournamentCreationWizard.this.setMinimumSize(new Dimension(450, 550));
 				}
 
 				SpringUtilities
@@ -643,6 +656,10 @@ public class XWingTournamentCreationWizard extends JDialog {
 			if (singleElimination.isSelected()) {
 				wizardOptions.setSingleElimination(true);
 			}
+			else if(roundRobin.isSelected()) {
+				wizardOptions.setRoundRobin(true);
+			}
+			
 
 			boolean fixByes = true;
 
@@ -839,8 +856,11 @@ public class XWingTournamentCreationWizard extends JDialog {
 
 		@Override
 		public JPanel getPanel() {
+			
 			setButtonVisibility(true, true, false);
 
+			XWingTournamentCreationWizard.this.setMinimumSize(new Dimension(450, 500));
+			
 			if (pagePanel == null) {
 				pagePanel = new JPanel(new BorderLayout());
 
@@ -978,6 +998,7 @@ public class XWingTournamentCreationWizard extends JDialog {
 		private boolean isMerge = false;
 		private List<XWingTournament> selectedTournaments;
 		private boolean isSingleElimination = false;
+		private boolean isRoundRobin = false;
 
 		public WizardOptions() {
 
@@ -989,6 +1010,7 @@ public class XWingTournamentCreationWizard extends JDialog {
 			this.points = wizardOptions.getPoints();
 			this.escalationPoints = wizardOptions.getEscalationPoints();
 			this.isSingleElimination = wizardOptions.isSingleElimination();
+			this.isRoundRobin = wizardOptions.isRoundRobin();
 		}
 
 		public InitialSeedingEnum getInitialSeedingEnum() {
@@ -1065,6 +1087,15 @@ public class XWingTournamentCreationWizard extends JDialog {
 		public void setSingleElimination(boolean isSingleElimination) {
 			this.isSingleElimination = isSingleElimination;
 		}
+
+		public boolean isRoundRobin() {
+			return isRoundRobin;
+		}
+
+		public void setRoundRobin(boolean isRoundRobin) {
+			this.isRoundRobin = isRoundRobin;
+		}
+
 	}
 
 	public List<XWingPlayer> rankMergedPlayers(List<XWingPlayer> playerList) {
@@ -1072,7 +1103,7 @@ public class XWingTournamentCreationWizard extends JDialog {
 				wizardOptions.getPlayerList(), null, wizardOptions
 						.getSelectedTournaments().get(0).getPoints(),
 				wizardOptions.getSelectedTournaments().get(0)
-						.getEscalationPoints(), false);
+						.getEscalationPoints(), false, false);
 		for (XWingTournament t : wizardOptions.getSelectedTournaments()) {
 			mergeTournament.getAllRounds().addAll(t.getAllRounds());
 		}


### PR DESCRIPTION
Added support for Round Robin-tournament. All players match up with eachother once. If the number of players are odd, each player gets one
bye.

One round is generated at a time, like normal. But players are rotated instead of matched up according to current record.