### PR TITLE
Add basic embedded web server support

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,11 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -1,72 +1,77 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>com.github.killerardvark</groupId>
-  <artifactId>cryodex</artifactId>
-  <packaging>jar</packaging>
-  <version>4.0.6-SNAPSHOT</version>
-  <name>cryodex</name>
-  <url>http://maven.apache.org</url>
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
-        <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
-        </configuration>
-      </plugin>
-      <plugin>
-      <!-- Build an executable JAR -->
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-jar-plugin</artifactId>
-         <version>2.4</version>
-         <configuration>
-           <archive>
-              <manifest>
-                <addClasspath>true</addClasspath>
-                <mainClass>cryodex.Main</mainClass>
-              </manifest>
-           </archive>
-         </configuration>
-       </plugin>
-    </plugins>
-  </build>
-  
-  <profiles>
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+   <groupId>com.github.killerardvark</groupId>
+   <artifactId>cryodex</artifactId>
+   <packaging>jar</packaging>
+   <version>4.0.6-SNAPSHOT</version>
+   <name>cryodex</name>
+   <url>http://maven.apache.org</url>
+   <dependencies>
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <version>4.12</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.eclipse.jetty</groupId>
+         <artifactId>jetty-server</artifactId>
+         <version>9.3.9.v20160517</version>
+      </dependency>
+   </dependencies>
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.3</version>
+            <configuration>
+               <source>1.7</source>
+               <target>1.7</target>
+            </configuration>
+         </plugin>
+         <plugin>
+            <!-- Build an executable JAR -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+            <configuration>
+               <archive>
+                  <manifest>
+                     <addClasspath>true</addClasspath>
+                     <mainClass>cryodex.Main</mainClass>
+                  </manifest>
+               </archive>
+            </configuration>
+         </plugin>
+      </plugins>
+   </build>
+
+   <profiles>
       <profile>
          <id>run</id>
          <build>
             <plugins>
-              <plugin>
-                 <groupId>org.codehaus.mojo</groupId>
-                 <artifactId>exec-maven-plugin</artifactId>
-                 <version>1.4.0</version>
-                 <executions>
-                    <execution>
+               <plugin>
+                  <groupId>org.codehaus.mojo</groupId>
+                  <artifactId>exec-maven-plugin</artifactId>
+                  <version>1.4.0</version>
+                  <executions>
+                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <goal>java</goal>
+                           <goal>java</goal>
                         </goals>
-                    </execution>
-                 </executions>
-                 <configuration>
+                     </execution>
+                  </executions>
+                  <configuration>
                      <mainClass>cryodex.Main</mainClass>
                      <classpathScope>compile</classpathScope>
                   </configuration>
-              </plugin>
+               </plugin>
             </plugins>
          </build>
       </profile>
-  </profiles>
+   </profiles>
 </project>

--- a/src/main/java/cryodex/Main.java
+++ b/src/main/java/cryodex/Main.java
@@ -11,6 +11,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.UIManager;
 import javax.swing.UIManager.LookAndFeelInfo;
 
+import cryodex.server.WebServer;
 import cryodex.widget.RegisterPanel;
 import cryodex.widget.SplashPanel;
 import cryodex.widget.TournamentTabbedPane;
@@ -172,6 +173,9 @@ public class Main extends JFrame {
 
 	public static void main(String[] args) {
 		new SplashPanel();
+		
+      WebServer webServer = WebServer.getInstance();
+      webServer.start();
 
 		Main.getInstance().setVisible(true);
 		Main.getInstance().setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);

--- a/src/main/java/cryodex/export/ExportUtils.java
+++ b/src/main/java/cryodex/export/ExportUtils.java
@@ -31,6 +31,18 @@ public class ExportUtils {
 
     }
     
+    public static String displayHTMLToString(String content) {
+       String preventTableBreak = "table.print-friendly {page-break-inside: avoid;}";
+       String mediaCss = "@media print {.pagebreak {page-break-after: always;}}";
+       String fancyCss = "table{border-collapse: collapse;}th{color:white; background-color:DarkSlateGray; font-size:120%;} tr:nth-child(odd){    background-color:lightgray;}";
+       String internationalCharacters = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />";
+       String html = "<html><head><style type=\"text/css\">.smallFont{font-size:10px}"
+               + fancyCss + mediaCss + preventTableBreak + "</style>" + internationalCharacters + "</head><body>" + content + "</body></html>";
+
+       return html;
+   }
+
+    
     
     public static void addTableStart(StringBuilder sb){
         sb.append("<table border=\"1\">");

--- a/src/main/java/cryodex/export/ExportUtils.java
+++ b/src/main/java/cryodex/export/ExportUtils.java
@@ -36,8 +36,9 @@ public class ExportUtils {
        String mediaCss = "@media print {.pagebreak {page-break-after: always;}}";
        String fancyCss = "table{border-collapse: collapse;}th{color:white; background-color:DarkSlateGray; font-size:120%;} tr:nth-child(odd){    background-color:lightgray;}";
        String internationalCharacters = "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />";
+       String refresh = "<META HTTP-EQUIV=\"refresh\" CONTENT=\"15\">";
        String html = "<html><head><style type=\"text/css\">.smallFont{font-size:10px}"
-               + fancyCss + mediaCss + preventTableBreak + "</style>" + internationalCharacters + "</head><body>" + content + "</body></html>";
+               + fancyCss + mediaCss + preventTableBreak + "</style>" + internationalCharacters +  refresh + "</head><body>" + content + "</body></html>";
 
        return html;
    }

--- a/src/main/java/cryodex/modules/xwing/XWingModule.java
+++ b/src/main/java/cryodex/modules/xwing/XWingModule.java
@@ -1,7 +1,11 @@
 package cryodex.modules.xwing;
 
+import javax.naming.InitialContext;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JDialog;
+
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.HandlerCollection;
 
 import cryodex.CryodexController;
 import cryodex.CryodexController.Modules;
@@ -12,8 +16,10 @@ import cryodex.modules.Module;
 import cryodex.modules.ModulePlayer;
 import cryodex.modules.RegistrationPanel;
 import cryodex.modules.Tournament;
+import cryodex.modules.xwing.server.XWingExportRankingsHandler;
 import cryodex.modules.xwing.wizard.WizardOptions;
 import cryodex.modules.xwing.wizard.XWingWizard;
+import cryodex.server.WebServer;
 import cryodex.xml.XMLUtils;
 import cryodex.xml.XMLUtils.Element;
 
@@ -37,7 +43,19 @@ public class XWingModule implements Module {
 	private boolean isEnabled = true;
 
 	private XWingModule() {
-
+	   init();
+	}
+	
+	private void init() {
+	   
+	   ContextHandler xwingContextHandler = new ContextHandler();
+	   xwingContextHandler.setContextPath("/xwing");
+	   HandlerCollection handlerCollection = new HandlerCollection();
+	   XWingExportRankingsHandler exportRankingsHandler = new XWingExportRankingsHandler();
+	   handlerCollection.addHandler(exportRankingsHandler);
+	   xwingContextHandler.setHandler(handlerCollection);
+	   
+	   WebServer.getInstance().addContextHandler(xwingContextHandler); 
 	}
 
 	@Override

--- a/src/main/java/cryodex/modules/xwing/export/XWingExportController.java
+++ b/src/main/java/cryodex/modules/xwing/export/XWingExportController.java
@@ -25,7 +25,7 @@ public class XWingExportController {
         playerList.addAll(tournament.getAllXWingPlayers());
         Collections.sort(playerList, new XWingComparator(tournament, XWingComparator.rankingCompare));
 
-        String content = "<table border=\"1\"><tr><th>Rank</th><th>Name</th><th>Faction</th><th>Score</th><th>MoV</th><th>SoS</th></tr>";
+        String content = "<table border=\"1\" width=\"100%\"><tr><th>Rank</th><th>Name</th><th>Faction</th><th>Score</th><th>MoV</th><th>SoS</th></tr>";
 
         for (XWingPlayer p : playerList) {
 

--- a/src/main/java/cryodex/modules/xwing/server/XWingExportRankingsHandler.java
+++ b/src/main/java/cryodex/modules/xwing/server/XWingExportRankingsHandler.java
@@ -35,7 +35,7 @@ public class XWingExportRankingsHandler extends AbstractHandler {
 
       } else {
          response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-         response.getWriter().println("<H1>Tournanment has not been started</H1>");
+         response.getWriter().println("<H1>Tournanment has been started</H1>");
       }
       
       baseRequest.setHandled(true);

--- a/src/main/java/cryodex/modules/xwing/server/XWingExportRankingsHandler.java
+++ b/src/main/java/cryodex/modules/xwing/server/XWingExportRankingsHandler.java
@@ -1,0 +1,43 @@
+package cryodex.modules.xwing.server;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+import cryodex.CryodexController;
+import cryodex.export.ExportUtils;
+import cryodex.modules.Tournament;
+import cryodex.modules.xwing.XWingTournament;
+import cryodex.modules.xwing.export.XWingExportController;
+
+public class XWingExportRankingsHandler extends AbstractHandler {
+
+   public XWingExportRankingsHandler() {
+   }
+
+   public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+         throws IOException, ServletException {
+      
+      Tournament activeTournament = CryodexController.getActiveTournament();
+      response.setContentType("text/html;charset=utf-8");
+      
+      if (activeTournament != null) {
+         String content = XWingExportController.appendRankings((XWingTournament) activeTournament);
+
+         String displayHTMLToString = ExportUtils.displayHTMLToString(content);
+         response.setStatus(HttpServletResponse.SC_OK);
+         response.getWriter().print(displayHTMLToString);
+
+      } else {
+         response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+         response.getWriter().println("<H1>Tournanment has not been started</H1>");
+      }
+      
+      baseRequest.setHandled(true);
+   }
+}

--- a/src/main/java/cryodex/server/HellowWorld.java
+++ b/src/main/java/cryodex/server/HellowWorld.java
@@ -1,0 +1,31 @@
+package cryodex.server;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+public class HellowWorld extends AbstractHandler {
+
+   public HellowWorld() {
+      // TODO Auto-generated constructor stub
+   }
+
+   public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
+         throws IOException, ServletException {
+      
+      if (target.contains("/xwing")) {
+         baseRequest.setHandled(false);
+         return;
+      }
+      
+      response.setContentType("text/html;charset=utf-8");
+      response.setStatus(HttpServletResponse.SC_OK);
+      baseRequest.setHandled(true);
+      response.getWriter().println("<h1>Hello World</h1>");
+   }
+}

--- a/src/main/java/cryodex/server/WebServer.java
+++ b/src/main/java/cryodex/server/WebServer.java
@@ -1,0 +1,79 @@
+package cryodex.server;
+
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.HandlerCollection;
+
+public class WebServer {
+
+   private Server server;
+   
+   private static WebServer webServer; 
+   
+   private WebServer() {
+   }
+   
+   public static  WebServer getInstance() {
+      if (webServer == null) {
+         webServer = new WebServer();
+      }
+      
+      return webServer;
+   }
+   
+   public boolean start() {
+      
+      try {
+         if (server == null || server.isStopped()) {
+            server = new Server(9080);
+            
+            HandlerCollection handlers = new HandlerCollection();
+            ContextHandler defaultContext = new ContextHandler();
+            defaultContext.setContextPath("/");
+            Handler handler = new HellowWorld();
+            defaultContext.setHandler(handler);
+            handlers.addHandler(defaultContext);
+            
+            server.setHandler(handlers); 
+            server.start();
+         }         
+      } catch (Exception  ex) {
+         return false;         
+      }
+      
+      return true;
+   }
+   
+   public boolean shutDown() {
+      if (server != null && (server.isRunning() || server.isStarted() )) {
+         try {
+            server.stop();
+            return true;
+         } catch (Exception e) {
+         }
+      }
+      return false;
+   }
+   
+   public synchronized void addContextHandler(ContextHandler contextHandler) {
+      
+      if (server != null && server.isStarted()) {
+         try {
+            server.stop();
+            HandlerCollection handlers = new HandlerCollection();
+            handlers.setHandlers(server.getHandlers());
+            handlers.addHandler(contextHandler);
+
+            server.setHandler(handlers);
+            server.start();
+         } catch (Exception e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+         }
+      }
+      
+   }
+
+}

--- a/src/main/java/cryodex/widget/SplashPanel.java
+++ b/src/main/java/cryodex/widget/SplashPanel.java
@@ -15,6 +15,7 @@ import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
 import cryodex.Main;
+import cryodex.server.WebServer;
 
 public class SplashPanel extends JWindow {
 
@@ -68,9 +69,12 @@ public class SplashPanel extends JWindow {
 		// Display it
 		setVisible(true);
 		toFront();
+		
 
 		new ResourceLoader().execute();
 	}
+	
+	
 
 	public class ResourceLoader extends SwingWorker<Object, Object> {
 


### PR DESCRIPTION
This adds some very basic web server support with
Contexts, using a basic jetty embedded web server.
Modules are free to implement there own contexts
to handle serving up web pages.

One potential use for this would be to provide
an API for integration into other X-Wing software
like Squad builders, Stream Helpers (i.e. display
current rankings on the stream), etc.

Right now it just servers up HTML files, but
could easily be made to serve up the XML or
even JSON files if necessary.

Usage:

http://localhost:9080/  - Will bring up the default context with Hello World just for testing purposes.
http://localhost:9080/xwing/   - Will display player Rankings for the currently active tournament.

This PR is more of a proof of concept and to feel if there is a desire for this to be added.   My own personal use would be to allow X-Wing Twitch and YouTube streamers to display the current rankings after each round on their stream.
